### PR TITLE
Make the Capsium package webextension work

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,24 +1,312 @@
-// Include the JSZip and JSON libraries
-importScripts('jszip.min.js');
+importScripts("./jszip.min.js");
 
-async function readCapFile(arrayBuffer) {
-  const zip = await JSZip.loadAsync(arrayBuffer);
+const capIdsWithTimeAddedStorageKey = "capIdsWithTimeAdded";
+const maxCapAge = 1000 * 60 * 30; // 30 minutes
+
+async function storeCapContents(manifest, routes, zip) {
+  // manifest.json format, It contains an content as a array of objects
+  // Where key is the file name and value is the content type
+  // {
+  // "content": [{"file": "example.css", "type": "text/css"}, {"file": "example.js", "type": "text/javascript"]
+  // }
+  //
+  // routes.json format, It contains the routes as a array of objects
+  // Where key is the path and value is the target file
+  // {
+  // "routes": [
+  // {
+  //    "path": "/",
+  //    "target": {
+  //      "file": "index.html"
+  //    }
+  //   },
+  //  {
+  //    "path": "/index",
+  //    "target": {
+  //      "file": "index.html"
+  //    }
+  //  },
+  //  {
+  //    "path": "/index.html",
+  //    "target": {
+  //      "file": "index.html"
+  //    }
+  //  },
+  //  {
+  //    "path": "/example.css",
+  //    "target": {
+  //      "file": "example.css"
+  //    }
+  //  },
+  //  {
+  //    "path": "/example.js",
+  //    "target": {
+  //      "file": "example.js"
+  //    }
+  //  }
+  // ]
+  //}
+
+  // Create a unique id for the CAP package
+  const capId = crypto.randomUUID();
+
+  const contentIds = [];
+  // Loop over each file in the manifest and read the content
+  for (const { file, mime } of manifest.content) {
+
+    const fileName = file;
+    const contentType = mime;
+
+    const contentPath = `content/${fileName}`
+
+    let fileContent = await zip.file(contentPath)?.async("text");
+
+    if (!fileContent) {
+      throw new Error(`File ${contentPath} not found in the CAP package`);
+    }
+
+    // If file is html, we need to replace the relative paths with absolute paths
+    // Without DOMParser, since we are in the background script
+    if (contentType === "text/html") {
+
+      const promise = new Promise((resolve, reject) => {
+        chrome.runtime.onMessage.addListener((message) => {
+          if(message.type === 'domParser') {
+            chrome.offscreen.closeDocument();
+            resolve(message.content);
+          }
+        });
+      });
+
+      await chrome.offscreen.createDocument({
+        url: chrome.runtime.getURL('domParserOffscreen.html'),
+        reasons: [chrome.offscreen.Reason.DOM_PARSER],
+        justification: 'We need to parse the HTML file to replace relative paths with absolute paths',
+      });
+
+      chrome.runtime.sendMessage({
+        type: 'domParser',
+        content: fileContent,
+        capId: capId
+      });
+
+      fileContent = await promise;
+    }
+
+    const fileId = `${capId}-${fileName}`;
+
+    // store it in the storage
+    await chrome.storage.local.set({ [fileId]: { type: 'content', fileName, contentType, fileContent } });
+
+    // Add the content id to the list of content ids
+    contentIds.push(fileId);
+  }
+
+  // store the manifest, routes and contentIds in the storage
+  await chrome.storage.local.set({
+    [capId]: {
+      type: 'capInfo',
+      manifest,
+      routes,
+      contentIds
+    }
+  });
+
+  // Storing the capId with current time in the storage
+  // This is used to delete the CAP package after a certain time
+  const capIdsWithTimeAddedResponse = await chrome.storage.local.get([capIdsWithTimeAddedStorageKey]);
+
+  const capIdsWithTimeAdded = capIdsWithTimeAddedResponse[capIdsWithTimeAddedStorageKey] || [];
+
+  capIdsWithTimeAdded.push({ capId, timeAdded: Date.now() });
+
+  await chrome.storage.local.set({ [capIdsWithTimeAddedStorageKey]: capIdsWithTimeAdded });
+
+  return capId;
+}
+
+const convertTextToDataURI = (text, contentType) => {
+  return `data:${contentType};base64,${btoa(text)}`;
+}
+
+async function setupCapRedirectRules(capId, routes) {
+
+  let id = 1;
+
+  const rules = [];
+  const deleteIds = [];
+  for (const { path, target } of routes) {
+
+    const url = `https://${capId}.cap${path}`;
+
+    const fileToUse = target.file;
+
+    const fileId = `${capId}-${fileToUse}`;
+
+    const contentInfo = await chrome.storage.local.get([fileId]);
+
+    if (!contentInfo[fileId]) {
+      throw new Error(`Content file ${fileToUse} not found for route ${path}`);
+    }
+
+    const { contentType, fileContent } = contentInfo[fileId];
+
+    const dataURI = convertTextToDataURI(fileContent, contentType);
+
+    const rule = {
+      id: id++,
+      priority: 1,
+      action: {
+        type: "redirect",
+        redirect: {
+          url: dataURI
+        }
+      },
+      condition: {
+        urlFilter: url,
+        resourceTypes: [
+          "main_frame",
+          "sub_frame",
+          "stylesheet",
+          "script",
+          "image",
+          "font",
+          "media"
+        ]
+      }
+    };
+
+    deleteIds.push(rule.id);
+    rules.push(rule);
+  }
+
+  await chrome.declarativeNetRequest.updateSessionRules({
+    removeRuleIds: deleteIds,
+    addRules: rules
+  });
+}
+
+async function readCapFile(fileBase64) {
+  const zip = await JSZip.loadAsync(fileBase64, { base64: true });
   const metadata = JSON.parse(await zip.file("metadata.json").async("text"));
   const manifest = JSON.parse(await zip.file("manifest.json").async("text"));
   const routes = JSON.parse(await zip.file("routes.json").async("text"));
 
-  return { metadata, manifest, routes, zip };
+  try {
+    const capId = await storeCapContents(manifest, routes, zip);
+    await setupCapRedirectRules(capId, routes.routes);
+
+    // Open a new tab with the CAP package URL
+    chrome.tabs.create({ url: `https://${capId}.cap/` });
+
+    return { metadata, manifest, routes, capId };
+  } catch (error) {
+    return { error: error.message };
+  }
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "openCapFile") {
-    const arrayBuffer = message.file;
-    readCapFile(arrayBuffer).then((pkg) => {
+    /**
+     * Understand, here base64 is quite important, since we can't send arrayBuffer or Blob directly
+     */
+    const fileBase64 = message.fileBase64;
+
+    readCapFile(fileBase64).then((pkg) => {
       sendResponse(pkg);
     }).catch((error) => {
       console.error("Error reading .cap file:", error);
       sendResponse({ error: "Failed to read .cap file" });
     });
+
     return true; // Keep the message channel open for async response
   }
 });
+
+// Setup a cron job to delete CAP packages that are older than maxCapAge
+chrome.alarms.create("30min", {
+  delayInMinutes: 30,
+  periodInMinutes: 30
+});
+
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+  if (alarm.name === "30min") {
+    let capIdsWithTimeAddedResponse = await chrome.storage.local.get([capIdsWithTimeAddedStorageKey]);
+
+    let capIdsWithTimeAdded = capIdsWithTimeAddedResponse[capIdsWithTimeAddedStorageKey] || [];
+
+    const currentTime = Date.now();
+
+    for (const { capId, timeAdded } of capIdsWithTimeAdded) {
+      if (currentTime - timeAdded > maxCapAge) {
+        // Delete the CAP package
+        const capInfo = await chrome.storage.local.get(capId);
+        if (capInfo) {
+          for (const contentId of capInfo.contentIds) {
+            await chrome.storage.local.remove(contentId);
+          }
+          await chrome.storage.local.remove(capId);
+        }
+
+        // Remove the capId from the list of capIdsWithTimeAdded
+        capIdsWithTimeAdded = capIdsWithTimeAdded.filter((item) => item.capId !== capId);
+      }
+    }
+
+    await chrome.storage.local.set({ [capIdsWithTimeAddedStorageKey]: capIdsWithTimeAdded });
+  }
+});
+
+/**
+ * This doesn't work since filterResponseData is not available in the chrome till now.
+ * What i was trying to do here being
+ * 1. Intercept the request
+ * 2. When user open the url CapId.cap, it should return the content of the capId based on the routes
+ * 3. We will fetch the capId from the url, will try to find it's data from the storage
+ * 4. We will then conditionally check the routes and return the content based on the routes
+ * 5. If the route is not found, we will return the default content
+ * 6. This way it's like capId.cap we have deployed our server.
+ * 
+ * But here the problem is, chrome don't allow us to modify the response of the request
+ * 
+ * 
+ * 2nd approach was when user open the url CapId.cap, we will modify the content after page load or before page load starts using content script.
+ * But here problem is this will not work for static contents like JS and CSS files.
+ * 
+ * So, we need to find a way to intercept the request and modify the response.
+ */
+/* chrome.declarativeNetRequest.updateSessionRules({
+  removeRuleIds: [
+    1,2,3,4,5,6,7,8,9,10,11,12
+  ],
+  addRules: [
+    {
+      id: 2,
+      priority: 1,
+      action: {
+        type: "redirect",
+        redirect: {
+          url: "data:text/javascript;base64,YWxlcnQoIkhlbGxvIGFuZCB3ZWxjb21lIik="
+        }
+      },
+      condition: {
+        regexFilter: "https://www\\.w3schools\\.com/lib/common-deps\\.js\\?v=[0-9]+\\.[0-9]+\\.[0-9]+",
+        resourceTypes: [
+          "main_frame",
+          "sub_frame",
+          "stylesheet",
+          "script",
+          "image",
+          "font",
+          "media"
+        ]
+      }
+    }
+  ]
+}, () => {
+  console.log("Rules added");
+})
+
+chrome.declarativeNetRequest.onRuleMatchedDebug.addListener(
+  (e) => console.log("onRuleMatchedDebug" + JSON.stringify(e))
+); */

--- a/domParserOffscreen.html
+++ b/domParserOffscreen.html
@@ -1,0 +1,15 @@
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+    <script src="domParserOffscreen.js">
+    </script>
+</body>
+
+</html>

--- a/domParserOffscreen.js
+++ b/domParserOffscreen.js
@@ -1,0 +1,28 @@
+chrome.runtime.onMessage.addListener(async (msg) => {
+
+    if(msg.type !== 'domParser') {
+        return;
+    }
+
+    // With message we will receive an html file
+    const doc = new DOMParser().parseFromString(msg.content, 'text/html');
+
+    const elements = doc.querySelectorAll("link[rel=stylesheet], script[src]");
+
+    for (const element of elements) {
+        const src = element.getAttribute("href") || element.getAttribute("src");
+
+        if (src && !src.startsWith("http")) {
+            const newSrc = `https://${msg.capId}.cap${src}`;
+            element.setAttribute("href", newSrc);
+            element.setAttribute("src", newSrc);
+        }
+    }
+
+    const fileContent = doc.documentElement.outerHTML;
+
+    chrome.runtime.sendMessage({
+        type: 'domParser',
+        content: fileContent,
+    });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,11 @@
   "description": "Chrome extension to view Capsium packages",
   "permissions": [
     "storage",
-    "activeTab"
+    "activeTab",
+    "unlimitedStorage",
+    "alarms",
+    "declarativeNetRequest",
+    "offscreen"
   ],
   "background": {
     "service_worker": "background.js"
@@ -14,7 +18,7 @@
     "default_popup": "popup.html"
   },
   "host_permissions": [
-    "file:///*"
+    "https://*.cap/*"
   ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/popup.html
+++ b/popup.html
@@ -11,9 +11,8 @@
 </head>
 <body>
   <h1>Capsium Viewer</h1>
-  <input type="file" id="capFileInput" accept=".cap" />
+  <input type="file" id="capFileInput" />
   <div id="packageInfo"></div>
-  <script type="module" src="/dist/popup.js"></script>
-  <!-- <script src="popup.js"></script> -->
+  <script type="text/javascript" src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,30 +1,45 @@
-document.getElementById("capFileInput").addEventListener("change", function(event) {
+const capFileInput = document.getElementById("capFileInput");
+const packageInfoDiv = document.getElementById("packageInfo");
+
+capFileInput.addEventListener("change", function(event) {
   const file = event.target.files[0];
   if (file) {
+
+    // check if file name ends with .cap
+    if (!file.name.toLowerCase().endsWith('.cap') && !file.name.toLowerCase().endsWith('.zip')) {
+      packageInfoDiv.textContent = 'Please select a .cap file';
+      return;
+    }
+
     const reader = new FileReader();
     reader.onload = function(event) {
-      const arrayBuffer = event.target.result;
-      chrome.runtime.sendMessage({ action: "openCapFile", file: arrayBuffer }, function(response) {
+      /**
+       * Understand, here base64 is quite important, since we can't send arrayBuffer or Blob directly
+       */
+      const base64String = event.target.result.split(",")[1];
+      chrome.runtime.sendMessage({ action: "openCapFile", fileBase64: base64String }, function(response) {
         if (response.error) {
-          document.getElementById("packageInfo").textContent = response.error;
+          packageInfoDiv.textContent = response.error;
         } else {
           displayPackageInfo(response);
         }
       });
     };
-    reader.readAsArrayBuffer(file);
+    reader.readAsDataURL(file);
   }
 });
 
-function displayPackageInfo(package) {
-  const infoDiv = document.getElementById("packageInfo");
-  infoDiv.innerHTML = `
+function displayPackageInfo(packageResponse) {
+
+  console.log(packageResponse);
+
+  packageInfoDiv.innerHTML = `
     <h2>Package Info</h2>
-    <p><strong>Name:</strong> ${package.metadata.name}</p>
-    <p><strong>Version:</strong> ${package.metadata.version}</p>
+    <p><strong>Name:</strong> ${packageResponse.metadata.name}</p>
+    <p><strong>Version:</strong> ${packageResponse.metadata.version}</p>
     <h3>Routes</h3>
     <ul>
-      ${package.routes.routes.map(route => `<li>${route.path} -> ${route.target.file}</li>`).join('')}
+      ${packageResponse.routes.routes.map(route => `<li>${route.path} -> ${route.target.file}</li>`).join('')}
     </ul>
   `;
 }


### PR DESCRIPTION
### Metanorma PR checklist
This PR introduces the solution that resolves the issue here: https://github.com/metanorma/capsium-webextension/issues/1

## Documentation on how this works
# Restrictions with Chrome extension
1. Chrome doesn't allow us to host multiple files as a static server.
2. We can't change the response body of HTTP requests.
3. Regarding static files like JS, We definitely can't run JS to make changes in the file.

# How this extension solves the problem
1. Chrome doesn't allow us to modify the response body for any HTTP request, but it does allow us to redirect it to somewhere else, and here is a key, We can also redirect it to the Data URI https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
2. When we upload the zip, the popup.js sends this to the background.js, Here previously there was a bug we were trying to send an array buffer, but the problem is, for runtime communication, we can use only JSON, and that's why I converted file into base64.
3. On background.js, we read the zip using the same jszip library and then store the contents in Chrome storage.
4. The point to consider here is, that we are also creating a unique ID for the cap file, called as caped
5. We are storing every content in the zip with the id "capId-FilePath"
6. While storing the HTML, we are making sure to replace each relative path with absolute path with our custom domain
7. We are also making sure to clear the storage after every 30 minutes.
8. But we have done with the storage, now what next?
9. For every capId, we are creating a custom domain URL like {capId}.cap
10. We are handling this {capId}.cap domain using declarativeNetRequest and then redirecting the it to the content data uri.